### PR TITLE
src/HTTPFetch.cc: set ne_set_request_body_buffer second argument to n…

### DIFF
--- a/src/HTTPFetch.cc
+++ b/src/HTTPFetch.cc
@@ -191,7 +191,7 @@ int MusicBrainz5::CHTTPFetch::Fetch(const std::string& URL, const std::string& R
 
 		ne_request *req = ne_request_create(sess, Request.c_str(), URL.c_str());
 		if (Request=="PUT")
-			ne_set_request_body_buffer(req,0,0);
+			ne_set_request_body_buffer(req,"",0);
 
 		if (Request!="GET")
 			ne_set_request_flag(req, NE_REQFLAG_IDEMPOTENT, 0);


### PR DESCRIPTION
…on-null

Fixes an issue in neon's header marking the function as `ne_attribute((nonnull));`

https://github.com/notroj/neon/blob/98c6943766fbd9b23da5ee0823f71b81e335789b/src/ne_request.h#L57

```c
C:/media-autobuild_suite-master/build/libmusicbrainz-git/src/HTTPFetch.cc: In member function 'int MusicBrainz5::CHTTPFetch::Fetch(const string&, const string&)':
C:/media-autobuild_suite-master/build/libmusicbrainz-git/src/HTTPFetch.cc:194:38: error: null argument where non-null required (argument 2) [-Werror=nonnull]
  194 |    ne_set_request_body_buffer(req,0,0);
      |                                      ^
cc1plus.exe: all warnings being treated as errors
```

I think this should unblock and issues of upgrading neon in mabs
